### PR TITLE
Maven Central アップロード対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile ('jp.studyplus.android.sdk:studyplus-android-sdk:2.0.0@aar') {
+    implementation ('jp.studyplus.android.sdk:studyplus-android-sdk2:2.0.0@aar') {
         transitive = true
     }
 }
@@ -23,7 +23,7 @@ dependencies {
 ```
 <dependency>
   <groupId>jp.studyplus.android.sdk</groupId>
-  <artifactId>studyplus-android-sdk</artifactId>
+  <artifactId>studyplus-android-sdk2</artifactId>
   <version>2.0.0</version>
 </dependency>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,7 @@ buildscript {
             'gson': '2.8.2',
             'okhttp': '3.10.0',
             'retrofit' : '2.4.0',
-            'rx2' : '2.0.2',
-            'moshi' : '1.6.0'
+            'rx2' : '2.0.2'
     ]
     repositories {
         google()

--- a/sdk-example-java/build.gradle
+++ b/sdk-example-java/build.gradle
@@ -23,13 +23,19 @@ android {
 
 }
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation "com.android.support:appcompat-v7:${versions.supportLibrary}"
     implementation "com.android.support.constraint:constraint-layout:${versions.constraintLayout}"
 
-    implementation project(':studyplus-android-sdk2')
+    implementation ('jp.studyplus.android.sdk:studyplus-android-sdk2:2.0.0@aar') {
+        transitive = true
+    }
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/sdk-example-kt/build.gradle
+++ b/sdk-example-kt/build.gradle
@@ -22,13 +22,19 @@ android {
     }
 }
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.android.support:appcompat-v7:${versions.supportLibrary}"
     implementation "com.android.support.constraint:constraint-layout:${versions.constraintLayout}"
 
-    implementation project(':studyplus-android-sdk2')
+    implementation ('jp.studyplus.android.sdk:studyplus-android-sdk2:2.0.0@aar') {
+        transitive = true
+    }
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/sdk-example-kt/src/main/java/jp/studyplus/android/sdk_example_kt/MainActivity.kt
+++ b/sdk-example-kt/src/main/java/jp/studyplus/android/sdk_example_kt/MainActivity.kt
@@ -3,8 +3,8 @@ package jp.studyplus.android.sdk_example_kt
 import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
@@ -26,18 +26,18 @@ class MainActivity : AppCompatActivity() {
                 getString(R.string.consumer_secret))
 
         findViewById<View>(R.id.start_auth)?.apply {
-            setOnClickListener({
+            setOnClickListener {
                 try {
                     Studyplus.instance.startAuth(this@MainActivity, REQUEST_CODE_AUTH)
                 } catch (e: ActivityNotFoundException) {
                     e.printStackTrace()
                     Toast.makeText(context, "Need for Studyplus 2.14.0+", Toast.LENGTH_LONG).show()
                 }
-            })
+            }
         }
 
         findViewById<View>(R.id.post_study_record)?.apply {
-            setOnClickListener({
+            setOnClickListener {
                 val record = StudyRecordBuilder()
                         .setComment("勉強した！！！")
                         .setAmountTotal(30)
@@ -56,7 +56,7 @@ class MainActivity : AppCompatActivity() {
                                 }
                             }
                         })
-            })
+            }
         }
     }
 

--- a/studyplus-android-sdk2/build.publish.gradle
+++ b/studyplus-android-sdk2/build.publish.gradle
@@ -1,32 +1,9 @@
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-task sourceJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier "source"
-}
-
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    destinationDir = file("../javadoc/")
-    failOnError false
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from tasks.javadoc.destinationDir
-}
-
-//Creating sources with comments
-task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
-}
-
-artifacts {
-    archives javadocJar
-    archives androidSourcesJar
+signing {
+    required { gradle.taskGraph.hasTask("uploadArchives") }
+    sign configurations.archives
 }
 
 uploadArchives {
@@ -41,8 +18,8 @@ uploadArchives {
             pom.project {
                 name "Studyplus Android SDK V2"
                 packaging 'aar'
-                description ''
-                artifactId "studyplus-android-sdk"
+                description 'Studyplus Android SDK V2'
+                artifactId "studyplus-android-sdk2"
                 url 'https://github.com/studyplus/Studyplus-Android-SDK-V2'
 
                 scm {


### PR DESCRIPTION
### Maven Central
- Javadoc除外
- source jar 除外
- description必須
- artifactId を `studyplus-android-sdk2` に変更（v1と区別するため）

### サンプルコード
- Maven Centralからダウンロード
- サンプルコード修正
- README.md 修正
