### PR TITLE
ConsumerKey と ConsumerSecret を動的変更対応

### DIFF
--- a/studyplus-android-sdk2/src/main/java/jp/studyplus/android/sdk/internal/api/ApiClient.kt
+++ b/studyplus-android-sdk2/src/main/java/jp/studyplus/android/sdk/internal/api/ApiClient.kt
@@ -5,7 +5,7 @@ import jp.studyplus.android.sdk.record.StudyRecord
 import kotlinx.coroutines.Deferred
 
 internal object ApiClient {
-    fun postStudyRecords(context: Context, studyRecord: StudyRecord): Deferred<Long?> {
-        return ApiService(ApiManager.client).post(CertificationStore.create(context).getOAuthAccessToken(), studyRecord.toJson())
+    fun postStudyRecords(context: Context, studyRecord: StudyRecord, consumerKey: String): Deferred<Long?> {
+        return ApiService(ApiManager.client).post(CertificationStore.create(context).apiCertification(consumerKey), studyRecord.toJson())
     }
 }

--- a/studyplus-android-sdk2/src/main/java/jp/studyplus/android/sdk/internal/api/CertificationStore.kt
+++ b/studyplus-android-sdk2/src/main/java/jp/studyplus/android/sdk/internal/api/CertificationStore.kt
@@ -1,16 +1,65 @@
 package jp.studyplus.android.sdk.internal.api
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
 import jp.studyplus.android.sdk.BuildConfig
+import org.json.JSONObject
 
 internal class CertificationStore
 private constructor(private val preferences: SharedPreferences) {
 
+    fun isAuthenticated(consumerKey: String) = tokenMap()[consumerKey]?.isNotEmpty() ?: false
+
+    fun apiCertification(consumerKey: String): String {
+        return tokenMap()[consumerKey] ?: throw IllegalStateException()
+    }
+
+    fun update(data: Intent, consumerKey: String) {
+        val code = data.getStringExtra(EXTRA_SP_AUTH_RESULT_CODE)
+        if (RESULT_CODE_AUTHENTICATED == code) {
+            preferences.edit()?.apply {
+                val newMap = tokenMap().plus(consumerKey to data.getStringExtra(EXTRA_SP_AUTH_ACCESS_TOKEN))
+                putString(KEY_ACCESS_TOKEN_MAP, toJson(newMap))
+                apply()
+            }
+        }
+    }
+
+    @SuppressLint("ApplySharedPref")
+    fun migration(consumerKey: String) {
+        val token = preferences.getString(KEY_ACCESS_TOKEN, null)
+        if (token.isNullOrEmpty()) {
+            return
+        }
+        preferences.edit().apply {
+            val map = toJson(mapOf(consumerKey to token))
+            putString(KEY_ACCESS_TOKEN_MAP, map)
+            remove(KEY_ACCESS_TOKEN)
+            commit()
+        }
+    }
+
+    private fun tokenMap(): Map<String, String> = fromJson(preferences.getString(KEY_ACCESS_TOKEN_MAP, null))
+
+    private fun toJson(map: Map<String, String>): String {
+        val json = JSONObject()
+        map.forEach { (key, value) -> json.put(key, value) }
+        return json.toString()
+    }
+
+    private fun fromJson(obj: String): Map<String, String> {
+        val json = JSONObject(obj)
+        val map = mutableMapOf<String, String>()
+        json.keys().forEach { map[it] = json[it] as String }
+        return map
+    }
+
     companion object {
         private const val KEY_ACCESS_TOKEN = "access_token"
+        private const val KEY_ACCESS_TOKEN_MAP = "access_token_map"
 
         private const val EXTRA_SP_AUTH_RESULT_CODE = "sp_auth_result_code"
         private const val EXTRA_SP_AUTH_ACCESS_TOKEN = "sp_auth_access_token"
@@ -21,26 +70,6 @@ private constructor(private val preferences: SharedPreferences) {
             val prefName = "Certification:" + Uri.parse(BuildConfig.API_ENDPOINT).host
             val pref = context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
             return CertificationStore(pref)
-        }
-    }
-
-    fun isAuthenticated(): Boolean {
-        val token = preferences.getString(KEY_ACCESS_TOKEN, "")
-        return !token.isNullOrEmpty()
-    }
-
-    fun getOAuthAccessToken(): String {
-        val certification = preferences.getString(KEY_ACCESS_TOKEN, "")
-        return "OAuth $certification"
-    }
-
-    fun update(data: Intent) {
-        val code = data.getStringExtra(EXTRA_SP_AUTH_RESULT_CODE).orEmpty()
-        if (RESULT_CODE_AUTHENTICATED == code) {
-            preferences.edit()?.apply {
-                putString(KEY_ACCESS_TOKEN, data.getStringExtra(EXTRA_SP_AUTH_ACCESS_TOKEN))
-                apply()
-            }
         }
     }
 }


### PR DESCRIPTION
# 背景

- 現在のSDKは Key と Secret がアプリ起動後に変更されることを想定していない
  - これまでSDKと連携するアプリが1対1のため変更する必要がなかった
- SDKを導入しているアプリで、ひとつのアプリが複数の連携アプリを持ち動的に切り替えたいニーズが出た

# 対応

- setupメソッドにより認証/投稿したいConsumerKeyとConsumerSecretを変更できるように変更
  - SharedPreferenceに保存する際Map<String, String>にて保存することで、ConsumerKeyごとに認証キーを保持するよう修正
  - ConsumerKeyの異なる状況で投稿したい場合には、StudyplusSDKインスタンスのConsumerKey/ConsumerSecretを切り替えてから投稿メソッドを利用

## 既存アプリへの影響

- SDK内部でmigration処理を実施するため、特になし