### PR TITLE
Kotlin Coroutinesの導入

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,20 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = '1.3.0'
     ext.versions = [
             'compileSdk': 27,
             'minSdk': 16,
             'targetSdk': 27,
             'supportLibrary': '27.1.1',
-            'constraintLayout': '1.1.3',
-            'gson': '2.8.5',
-            'okhttp': '3.10.0',
-            'retrofit' : '2.4.0',
-            'rx2java' : '2.2.0',
-            'rx2android' : '2.1.0'
+            'constraintLayout': '1.1.3'
     ]
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jul 01 16:03:41 JST 2018
+#Tue Oct 30 15:28:34 JST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/studyplus-android-sdk2/build.gradle
+++ b/studyplus-android-sdk2/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2'
 
     testImplementation 'junit:junit:4.12'
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 }
 
 apply from: 'build.publish.gradle'

--- a/studyplus-android-sdk2/build.gradle
+++ b/studyplus-android-sdk2/build.gradle
@@ -33,6 +33,8 @@ android {
         version = versionName
         group = "jp.studyplus.android.sdk"
 
+        consumerProguardFiles 'lib-proguard-rules.txt'
+
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -44,9 +46,6 @@ android {
             initWith(buildTypes.debug)
         }
         release {
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-
             buildConfigField "String", "API_ENDPOINT", quote("https://external-api.studyplus.jp")
         }
     }
@@ -66,19 +65,18 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.0.0'
 
     implementation 'com.google.code.gson:gson:2.8.5'
-
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
 
     def retrofit = "2.4.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofit"
-    implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofit"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit"
     testImplementation "com.squareup.retrofit2:retrofit-mock:$retrofit"
 
-    implementation "io.reactivex.rxjava2:rxjava:2.2.2"
-    implementation "io.reactivex.rxjava2:rxandroid:2.1.0"
+    implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/studyplus-android-sdk2/build.gradle
+++ b/studyplus-android-sdk2/build.gradle
@@ -65,23 +65,22 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    implementation "com.google.code.gson:gson:${versions.gson}"
+    implementation 'com.google.code.gson:gson:2.8.5'
 
-    implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
-    implementation "com.squareup.okhttp3:logging-interceptor:${versions.okhttp}"
+    implementation 'com.squareup.okhttp3:okhttp:3.11.0'
 
-    implementation "com.squareup.retrofit2:retrofit:${versions.retrofit}"
-    implementation "com.squareup.retrofit2:adapter-rxjava2:${versions.retrofit}"
-    implementation "com.squareup.retrofit2:converter-gson:${versions.retrofit}"
-    testImplementation "com.squareup.retrofit2:retrofit-mock:${versions.retrofit}"
+    def retrofit = "2.4.0"
+    implementation "com.squareup.retrofit2:retrofit:$retrofit"
+    implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofit"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofit"
+    testImplementation "com.squareup.retrofit2:retrofit-mock:$retrofit"
 
-    implementation "io.reactivex.rxjava2:rxjava:${versions.rx2java}"
-    implementation "io.reactivex.rxjava2:rxandroid:${versions.rx2android}"
+    implementation "io.reactivex.rxjava2:rxjava:2.2.2"
+    implementation "io.reactivex.rxjava2:rxandroid:2.1.0"
 
     testImplementation 'junit:junit:4.12'
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 apply from: 'build.publish.gradle'

--- a/studyplus-android-sdk2/lib-proguard-rules.pro
+++ b/studyplus-android-sdk2/lib-proguard-rules.pro
@@ -20,5 +20,14 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keep public class jp.studyplus.android.sdk.* { public *; }
--keep public class jp.studyplus.android.sdk.record.** { public *; }
+# ServiceLoader support
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+
+# Most of volatile fields are updated with AFU and should not be mangled
+-keepclassmembernames class kotlinx.** {
+    volatile <fields>;
+}
+
+# Network Rsponse
+-keepnames class jp.studyplus.android.sdk.internal.api.response.** { *; }

--- a/studyplus-android-sdk2/src/main/java/jp/studyplus/android/sdk/internal/api/ApiClient.kt
+++ b/studyplus-android-sdk2/src/main/java/jp/studyplus/android/sdk/internal/api/ApiClient.kt
@@ -1,30 +1,14 @@
 package jp.studyplus.android.sdk.internal.api
 
 import android.content.Context
-import io.reactivex.Observable
 import jp.studyplus.android.sdk.internal.api.response.PostStudyRecordsResponse
 import jp.studyplus.android.sdk.record.StudyRecord
-import retrofit2.Retrofit
+import kotlinx.coroutines.Deferred
 
-internal class ApiClient
-constructor(retrofit: Retrofit) {
+internal object ApiClient {
+    private val apiService by lazy { ApiManager.retrofit.create(ApiService::class.java) }
 
-    companion object {
-        val apiClient by lazy { ApiClient(ApiManager.retrofit) }
-        lateinit var apiService: ApiService
-
-        private fun getOAuthAccessToken(context: Context): Observable<String> {
-            return Observable.just(CertificationStore.create(context))
-                    .map { it.apiCertification() }
-                    .map { "OAuth $it" }
-        }
-    }
-
-    init {
-        apiService = retrofit.create(ApiService::class.java)
-    }
-
-    fun postStudyRecords(context: Context, studyRecord: StudyRecord): Observable<PostStudyRecordsResponse> {
-        return getOAuthAccessToken(context).flatMap { apiService.postStudyRecords(it, studyRecord) }
+    fun postStudyRecords(context: Context, studyRecord: StudyRecord): Deferred<PostStudyRecordsResponse> {
+        return apiService.postStudyRecords(CertificationStore.create(context).getOAuthAccessToken(), studyRecord)
     }
 }

--- a/studyplus-android-sdk2/src/main/java/jp/studyplus/android/sdk/internal/api/ApiManager.kt
+++ b/studyplus-android-sdk2/src/main/java/jp/studyplus/android/sdk/internal/api/ApiManager.kt
@@ -1,15 +1,15 @@
 package jp.studyplus.android.sdk.internal.api
 
+import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import jp.studyplus.android.sdk.BuildConfig
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
-import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
 
 internal object ApiManager {
 
-    private val client by lazy {
+    private val client: OkHttpClient by lazy {
         OkHttpClient.Builder()
                 .connectTimeout(60, TimeUnit.SECONDS)
                 .writeTimeout(60, TimeUnit.SECONDS)
@@ -17,12 +17,12 @@ internal object ApiManager {
                 .build()
     }
 
-    val retrofit by lazy {
+    val retrofit: Retrofit by lazy {
         Retrofit.Builder()
                 .client(client)
                 .baseUrl(BuildConfig.API_ENDPOINT)
-                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+                .addCallAdapterFactory(CoroutineCallAdapterFactory())
                 .addConverterFactory(GsonConverterFactory.create())
-                .build()!!
+                .build()
     }
 }

--- a/studyplus-android-sdk2/src/main/java/jp/studyplus/android/sdk/internal/api/ApiService.kt
+++ b/studyplus-android-sdk2/src/main/java/jp/studyplus/android/sdk/internal/api/ApiService.kt
@@ -1,9 +1,12 @@
 package jp.studyplus.android.sdk.internal.api
 
-import io.reactivex.Observable
 import jp.studyplus.android.sdk.internal.api.response.PostStudyRecordsResponse
 import jp.studyplus.android.sdk.record.StudyRecord
-import retrofit2.http.*
+import kotlinx.coroutines.Deferred
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.Headers
+import retrofit2.http.POST
 
 internal interface ApiService {
     @Headers(value = [
@@ -13,6 +16,6 @@ internal interface ApiService {
     @POST("/v1/study_records")
     fun postStudyRecords(
             @Header("Authorization") oauth: String,
-            @Body studyRecord: StudyRecord)
-            : Observable<PostStudyRecordsResponse>
+            @Body studyRecord: StudyRecord
+    ): Deferred<PostStudyRecordsResponse>
 }

--- a/studyplus-android-sdk2/src/main/java/jp/studyplus/android/sdk/internal/api/CertificationStore.kt
+++ b/studyplus-android-sdk2/src/main/java/jp/studyplus/android/sdk/internal/api/CertificationStore.kt
@@ -29,7 +29,10 @@ private constructor(private val preferences: SharedPreferences) {
         return !token.isNullOrEmpty()
     }
 
-    fun apiCertification(): String = preferences.getString(KEY_ACCESS_TOKEN, "")
+    fun getOAuthAccessToken(): String {
+        val certification = preferences.getString(KEY_ACCESS_TOKEN, "")
+        return "OAuth $certification"
+    }
 
     fun update(data: Intent) {
         val code = data.getStringExtra(EXTRA_SP_AUTH_RESULT_CODE).orEmpty()

--- a/studyplus-android-sdk2/src/test/java/jp/studyplus/android/sdk/ApiUnitTest.kt
+++ b/studyplus-android-sdk2/src/test/java/jp/studyplus/android/sdk/ApiUnitTest.kt
@@ -2,22 +2,25 @@ package jp.studyplus.android.sdk
 
 import jp.studyplus.android.sdk.internal.api.MockApiClient
 import jp.studyplus.android.sdk.record.StudyRecordBuilder
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class ApiUnitTest {
 
     @Test
     fun mockApi() {
         val record = StudyRecordBuilder().build()
-        MockApiClient.apiClient.postStudyRecords(null, record)
-                .test()
-                .assertNoErrors()
-                .assertValue {
-                    it.recordId?.let {
-                        it == 9999L
-                    } ?: run {
-                        false
-                    }
-                }
+        runBlocking {
+            try {
+                val deferred = MockApiClient.apiClient.postStudyRecords(null, record)
+                val result = deferred.await()
+
+                assertEquals(result.recordId, 9999L)
+            } catch (t: Throwable) {
+                assertNull(t)
+            }
+        }
     }
 }

--- a/studyplus-android-sdk2/src/test/java/jp/studyplus/android/sdk/internal/api/MockApiClient.kt
+++ b/studyplus-android-sdk2/src/test/java/jp/studyplus/android/sdk/internal/api/MockApiClient.kt
@@ -1,13 +1,10 @@
 package jp.studyplus.android.sdk.internal.api
 
 import android.content.Context
-import io.reactivex.Observable
-import jp.studyplus.android.sdk.internal.api.response.PostStudyRecordsResponse
 import jp.studyplus.android.sdk.record.StudyRecord
 import retrofit2.mock.MockRetrofit
 
-internal class MockApiClient
-constructor(retrofit: MockRetrofit) {
+internal class MockApiClient constructor(retrofit: MockRetrofit) {
 
     companion object {
         val apiClient by lazy { MockApiClient(MockApiManager.retrofit) }
@@ -19,7 +16,6 @@ constructor(retrofit: MockRetrofit) {
         apiService = MockApiService(delegate)
     }
 
-    fun postStudyRecords(context: Context?, studyRecord: StudyRecord): Observable<PostStudyRecordsResponse> {
-        return apiService.postStudyRecords("", studyRecord)
-    }
+    fun postStudyRecords(context: Context?, studyRecord: StudyRecord) =
+            apiService.postStudyRecords("", studyRecord)
 }

--- a/studyplus-android-sdk2/src/test/java/jp/studyplus/android/sdk/internal/api/MockApiService.kt
+++ b/studyplus-android-sdk2/src/test/java/jp/studyplus/android/sdk/internal/api/MockApiService.kt
@@ -1,12 +1,12 @@
 package jp.studyplus.android.sdk.internal.api
 
-import io.reactivex.Observable
 import jp.studyplus.android.sdk.internal.api.response.PostStudyRecordsResponse
 import jp.studyplus.android.sdk.record.StudyRecord
+import kotlinx.coroutines.Deferred
 import retrofit2.mock.BehaviorDelegate
 
 internal class MockApiService(private val delegate: BehaviorDelegate<ApiService>) : ApiService {
-    override fun postStudyRecords(oauth: String, studyRecord: StudyRecord): Observable<PostStudyRecordsResponse> {
+    override fun postStudyRecords(oauth: String, studyRecord: StudyRecord): Deferred<PostStudyRecordsResponse> {
         return delegate.returningResponse(PostStudyRecordsResponse(9999)).postStudyRecords(oauth, studyRecord)
     }
 }


### PR DESCRIPTION
- Kotlin 1.3を導入
- RxJavaで行っていた通信処理をKotlin Coroutinesに置き換え
- テストコードを更新
- Proguardの指定をライブラリのものに修正